### PR TITLE
Add agent schema and CLI for runtime JSON generation

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,31 @@
+"""Agent package exposing generator utilities for runtime JSON files."""
+from .assetpack_agent import AssetPackAgent, AssetPackRequest
+from .exporter_agent import ExporterAgent, ExporterRequest
+from .forcefield_agent import ForceFieldAgent, ForceEventSpec, ForcefieldConstraints, ForcefieldRequest
+from .obstacle_agent import ObstacleAgent, ObstacleRequest
+from .preset_agent import PresetAgent, PresetConstraints, PresetRequest
+from .sequence_agent import SequenceAgent, SequenceRequest
+from .timekeeper_agent import TimekeeperAgent, TimekeeperRequest
+from .uihints_agent import UIHintsAgent, UIHintsRequest
+
+__all__ = [
+    "PresetAgent",
+    "PresetRequest",
+    "PresetConstraints",
+    "ForceFieldAgent",
+    "ForcefieldRequest",
+    "ForcefieldConstraints",
+    "ForceEventSpec",
+    "ObstacleAgent",
+    "ObstacleRequest",
+    "SequenceAgent",
+    "SequenceRequest",
+    "TimekeeperAgent",
+    "TimekeeperRequest",
+    "UIHintsAgent",
+    "UIHintsRequest",
+    "ExporterAgent",
+    "ExporterRequest",
+    "AssetPackAgent",
+    "AssetPackRequest",
+]

--- a/agents/assetpack_agent.py
+++ b/agents/assetpack_agent.py
@@ -1,0 +1,26 @@
+"""Asset pack agent ensures runtime assets are catalogued."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .schema import AssetPackSchema
+
+
+@dataclass
+class AssetPackRequest:
+    required_assets: Iterable[str]
+    available_assets: Iterable[str]
+
+
+class AssetPackAgent:
+    """Produce asset pack reports listing missing dependencies."""
+
+    def generate(self, request: AssetPackRequest) -> AssetPackSchema:
+        required = list(dict.fromkeys(request.required_assets))
+        available = set(request.available_assets)
+        missing = [asset for asset in required if asset not in available]
+        return AssetPackSchema(required_assets=required, missing_assets=missing)
+
+
+__all__ = ["AssetPackAgent", "AssetPackRequest"]

--- a/agents/exporter_agent.py
+++ b/agents/exporter_agent.py
@@ -1,0 +1,24 @@
+"""Exporter agent prepares capture instructions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .schema import CaptureSettings, ExporterSchema
+
+
+@dataclass
+class ExporterRequest:
+    capture: CaptureSettings
+    watermark: Optional[dict] = None
+    seed: Optional[int] = None
+
+
+class ExporterAgent:
+    """Compose exporter schemas suitable for runtime consumption."""
+
+    def generate(self, request: ExporterRequest) -> ExporterSchema:
+        return ExporterSchema(capture=request.capture, watermark=request.watermark, seed=request.seed)
+
+
+__all__ = ["ExporterAgent", "ExporterRequest"]

--- a/agents/forcefield_agent.py
+++ b/agents/forcefield_agent.py
@@ -1,0 +1,63 @@
+"""Forcefield agent builds forcefield.v1.json compatible structures."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Optional
+
+from .schema import ForceEvent, ForcefieldSchema, MAX_WIND_SPEED, clamp
+
+
+@dataclass
+class ForceEventSpec:
+    t: float
+    type: str
+    dir_deg: Optional[float] = None
+    speed: Optional[float] = None
+    dur: Optional[float] = None
+    center: Optional[List[float]] = None
+    radius: Optional[float] = None
+    vortex: Optional[float] = None
+
+
+@dataclass
+class ForcefieldConstraints:
+    max_speed: float = MAX_WIND_SPEED
+
+
+@dataclass
+class ForcefieldRequest:
+    prompt: str
+    events: Iterable[ForceEventSpec]
+    use_prebaked_texture: bool = False
+
+
+class ForceFieldAgent:
+    """Generate forcefield schemas based on structured event specs."""
+
+    def __init__(self, constraints: ForcefieldConstraints | None = None) -> None:
+        self.constraints = constraints or ForcefieldConstraints()
+
+    def _apply_constraints(self, event: ForceEventSpec) -> ForceEvent:
+        speed = event.speed
+        if speed is not None:
+            speed = clamp(speed, min_value=0.0, max_value=self.constraints.max_speed)
+        vortex = event.vortex
+        if vortex is not None:
+            vortex = clamp(vortex, min_value=0.0, max_value=self.constraints.max_speed * 1.25)
+        return ForceEvent(
+            t=event.t,
+            type=event.type,
+            dir_deg=event.dir_deg,
+            speed=speed,
+            dur=event.dur,
+            center=event.center,
+            radius=event.radius,
+            vortex=vortex,
+        )
+
+    def generate(self, request: ForcefieldRequest) -> ForcefieldSchema:
+        events = [self._apply_constraints(event) for event in request.events]
+        return ForcefieldSchema(timeline=events, use_prebaked_texture=request.use_prebaked_texture)
+
+
+__all__ = ["ForceFieldAgent", "ForcefieldRequest", "ForcefieldConstraints", "ForceEventSpec"]

--- a/agents/obstacle_agent.py
+++ b/agents/obstacle_agent.py
@@ -1,0 +1,28 @@
+"""Obstacle agent generates obstacles.v1.json compatible data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .schema import ClearRule, DrawOp, ObstaclesSchema
+
+
+@dataclass
+class ObstacleRequest:
+    clear_rules: Iterable[ClearRule]
+    draw_ops: Iterable[DrawOp]
+    mask_path: str = "res://runtime/obstacles_mask.png"
+
+
+class ObstacleAgent:
+    """Create obstacle layouts from structured instructions."""
+
+    def generate(self, request: ObstacleRequest) -> ObstaclesSchema:
+        return ObstaclesSchema(
+            clear_rules=list(request.clear_rules),
+            draw_ops=list(request.draw_ops),
+            mask_path=request.mask_path,
+        )
+
+
+__all__ = ["ObstacleAgent", "ObstacleRequest"]

--- a/agents/preset_agent.py
+++ b/agents/preset_agent.py
@@ -1,0 +1,105 @@
+"""Preset agent responsible for authoring preset.v1.json structures."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from .schema import (
+    MAX_PARTICLE_RATE,
+    AccumulationSettings,
+    AppearanceSettings,
+    BackgroundSettings,
+    BurstSettings,
+    EmitterSettings,
+    FXSettings,
+    MotionSettings,
+    ObstacleSettings,
+    PresetSchema,
+    SizeRange,
+    SpawnBand,
+    TargetsSettings,
+    clamp,
+)
+
+
+@dataclass
+class PresetConstraints:
+    max_particles: int = MAX_PARTICLE_RATE
+    target_fps: int = 60
+    internal_scale: float = 0.75
+
+
+@dataclass
+class PresetRequest:
+    prompt: str
+    palette: Optional[Sequence[str]] = None
+    emitter_type: str = "generic"
+    base_name: str = "custom"
+    desired_rate: int = 2000
+    burst_interval: Optional[float] = None
+    burst_count: Optional[int] = None
+    sprite: str = "res://runtime/preset_sprite.png"
+    notes: Optional[str] = None
+
+
+class PresetAgent:
+    """Generate preset schemas using lightweight heuristics."""
+
+    def __init__(self, constraints: PresetConstraints | None = None) -> None:
+        self.constraints = constraints or PresetConstraints()
+
+    @staticmethod
+    def _slugify(text: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+        return slug or "preset"
+
+    @staticmethod
+    def _choose_motion(prompt: str) -> MotionSettings:
+        prompt_lower = prompt.lower()
+        if "storm" in prompt_lower or "strong" in prompt_lower:
+            return MotionSettings(drag=0.05, sway_amp=50.0, sway_freq=0.9, spin_deg_per_sec=120.0, gravity=320.0, glide_lift=0.4)
+        if "calm" in prompt_lower or "gentle" in prompt_lower:
+            return MotionSettings(drag=0.18, sway_amp=18.0, sway_freq=0.4, spin_deg_per_sec=40.0, gravity=120.0, glide_lift=0.2)
+        return MotionSettings(drag=0.12, sway_amp=30.0, sway_freq=0.6, spin_deg_per_sec=90.0, gravity=240.0, glide_lift=0.3)
+
+    @staticmethod
+    def _appearance(palette: Optional[Sequence[str]], sprite: str) -> AppearanceSettings:
+        if not palette:
+            palette = ["#ffffff", "#dddddd", "#bbbbbb"]
+        size = SizeRange(min=6, max=14)
+        return AppearanceSettings(list(palette), size, sprite)
+
+    def generate(self, request: PresetRequest) -> PresetSchema:
+        slug = self._slugify(request.base_name or request.prompt)
+        emitter_rate = int(clamp(float(request.desired_rate), min_value=1.0, max_value=float(self.constraints.max_particles)))
+        burst = None
+        if request.burst_interval is not None and request.burst_count is not None:
+            burst = BurstSettings(interval_sec=request.burst_interval, count=request.burst_count)
+        emitter = EmitterSettings(
+            type=request.emitter_type,
+            rate_per_sec=emitter_rate,
+            spawn_band=SpawnBand(y=0.05, height=0.02),
+            burst=burst,
+        )
+        appearance = self._appearance(request.palette, request.sprite)
+        motion = self._choose_motion(request.prompt)
+        accumulation = AccumulationSettings(enabled=True, mode="heightmap", max_height_px=180.0, diffusion=0.08)
+        obstacle = ObstacleSettings(collide_mask="res://runtime/obstacles_mask.png", stickiness=0.2)
+        fx = FXSettings(bloom=0.2, background=BackgroundSettings(["#0b1120", "#1e293b"], cycle_by_clock=False))
+        targets = TargetsSettings(fps=self.constraints.target_fps, internal_scale=self.constraints.internal_scale)
+        notes = (request.notes or request.prompt)[:80]
+        return PresetSchema(
+            name=slug,
+            emitter=emitter,
+            appearance=appearance,
+            motion=motion,
+            accumulation=accumulation,
+            obstacle=obstacle,
+            fx=fx,
+            targets=targets,
+            notes=notes,
+        )
+
+
+__all__ = ["PresetAgent", "PresetRequest", "PresetConstraints"]

--- a/agents/schema.py
+++ b/agents/schema.py
@@ -1,0 +1,551 @@
+"""Shared schema and validation helpers for runtime JSON generation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+SCHEMA_VERSION = "1.0"
+MAX_PARTICLE_RATE = 100_000
+MAX_BURST_COUNT = 100_000
+MAX_WIND_SPEED = 400.0
+MAX_VORTEX_SPEED = 500.0
+MAX_TORNADO_RADIUS = 0.5
+MAX_ACCUMULATION_HEIGHT = 512.0
+MAX_EXPORT_DURATION = 120.0
+MAX_EXPORT_RESOLUTION = 4096
+
+
+class ValidationError(ValueError):
+    """Raised when incoming data violates schema constraints."""
+
+
+def clamp(value: float, *, min_value: Optional[float] = None, max_value: Optional[float] = None) -> float:
+    """Clamp *value* inside the provided range."""
+
+    if value != value:  # NaN check
+        raise ValidationError("value cannot be NaN")
+    if min_value is not None and value < min_value:
+        value = min_value
+    if max_value is not None and value > max_value:
+        value = max_value
+    return value
+
+
+def ensure_runtime_path(path: str) -> str:
+    """Validate that a resource path lives under ``res://runtime/``."""
+
+    if not path.startswith("res://runtime/"):
+        raise ValidationError("runtime assets must be stored under res://runtime/")
+    return path
+
+
+def ensure_palette(palette: Iterable[str]) -> List[str]:
+    colors = [color for color in palette if color]
+    if not colors:
+        raise ValidationError("palette must contain at least one color")
+    return colors
+
+
+@dataclass
+class RuntimeJSON:
+    version: str = SCHEMA_VERSION
+
+    def to_dict(self) -> Dict[str, Any]:  # pragma: no cover - subclasses override
+        raise NotImplementedError
+
+
+@dataclass
+class BurstSettings:
+    interval_sec: float
+    count: int
+
+    def __post_init__(self) -> None:
+        self.interval_sec = clamp(self.interval_sec, min_value=0.0)
+        self.count = int(clamp(float(self.count), min_value=0.0, max_value=MAX_BURST_COUNT))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"interval_sec": self.interval_sec, "count": self.count}
+
+
+@dataclass
+class SpawnBand:
+    y: float
+    height: float
+
+    def __post_init__(self) -> None:
+        self.y = clamp(self.y, min_value=0.0, max_value=1.0)
+        self.height = clamp(self.height, min_value=0.0, max_value=1.0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"y": self.y, "height": self.height}
+
+
+@dataclass
+class EmitterSettings:
+    type: str
+    rate_per_sec: int
+    spawn_band: SpawnBand
+    burst: Optional[BurstSettings] = None
+    random_seed: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        self.rate_per_sec = int(
+            clamp(float(self.rate_per_sec), min_value=0.0, max_value=float(MAX_PARTICLE_RATE))
+        )
+        if self.random_seed is not None:
+            self.random_seed = int(self.random_seed) & 0xFFFFFFFF
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "type": self.type,
+            "rate_per_sec": self.rate_per_sec,
+            "spawn_band": self.spawn_band.to_dict(),
+        }
+        if self.burst:
+            data["burst"] = self.burst.to_dict()
+        if self.random_seed is not None:
+            data["random_seed"] = self.random_seed
+        return data
+
+
+@dataclass
+class SizeRange:
+    min: float
+    max: float
+
+    def __post_init__(self) -> None:
+        self.min = clamp(self.min, min_value=0.0)
+        self.max = clamp(self.max, min_value=max(self.min, 0.0))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"min": self.min, "max": self.max}
+
+
+@dataclass
+class AppearanceSettings:
+    palette: List[str]
+    size_px: SizeRange
+    sprite: str
+
+    def __post_init__(self) -> None:
+        self.palette = ensure_palette(self.palette)
+        if not self.sprite:
+            raise ValidationError("sprite path cannot be empty")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "palette": self.palette,
+            "size_px": self.size_px.to_dict(),
+            "sprite": self.sprite,
+        }
+
+
+@dataclass
+class MotionSettings:
+    drag: float
+    sway_amp: float
+    sway_freq: float
+    spin_deg_per_sec: float
+    gravity: float
+    glide_lift: float
+
+    def __post_init__(self) -> None:
+        self.drag = clamp(self.drag, min_value=0.0, max_value=5.0)
+        self.sway_amp = clamp(self.sway_amp, min_value=0.0, max_value=180.0)
+        self.sway_freq = clamp(self.sway_freq, min_value=0.0, max_value=5.0)
+        self.spin_deg_per_sec = clamp(self.spin_deg_per_sec, min_value=-720.0, max_value=720.0)
+        self.gravity = clamp(self.gravity, min_value=-5000.0, max_value=5000.0)
+        self.glide_lift = clamp(self.glide_lift, min_value=0.0, max_value=5.0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "drag": self.drag,
+            "sway": {"amp": self.sway_amp, "freq": self.sway_freq},
+            "spin": {"deg_per_sec": self.spin_deg_per_sec},
+            "gravity": self.gravity,
+            "glide": {"lift": self.glide_lift},
+        }
+
+
+@dataclass
+class AccumulationSettings:
+    enabled: bool
+    mode: str
+    max_height_px: float
+    diffusion: float
+
+    def __post_init__(self) -> None:
+        self.max_height_px = clamp(self.max_height_px, min_value=0.0, max_value=MAX_ACCUMULATION_HEIGHT)
+        self.diffusion = clamp(self.diffusion, min_value=0.0, max_value=1.0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "mode": self.mode,
+            "max_height_px": self.max_height_px,
+            "diffusion": self.diffusion,
+        }
+
+
+@dataclass
+class ObstacleSettings:
+    collide_mask: str
+    stickiness: float
+
+    def __post_init__(self) -> None:
+        self.collide_mask = ensure_runtime_path(self.collide_mask)
+        self.stickiness = clamp(self.stickiness, min_value=0.0, max_value=1.0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"collide_mask": self.collide_mask, "stickiness": self.stickiness}
+
+
+@dataclass
+class BackgroundSettings:
+    gradient: List[str]
+    cycle_by_clock: bool = False
+
+    def __post_init__(self) -> None:
+        self.gradient = ensure_palette(self.gradient)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"gradient": self.gradient, "cycle_by_clock": self.cycle_by_clock}
+
+
+@dataclass
+class FXSettings:
+    bloom: float
+    background: BackgroundSettings
+
+    def __post_init__(self) -> None:
+        self.bloom = clamp(self.bloom, min_value=0.0, max_value=2.0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"bloom": self.bloom, "background": self.background.to_dict()}
+
+
+@dataclass
+class TargetsSettings:
+    fps: int
+    internal_scale: float
+
+    def __post_init__(self) -> None:
+        self.fps = int(clamp(float(self.fps), min_value=1.0, max_value=240.0))
+        self.internal_scale = clamp(self.internal_scale, min_value=0.1, max_value=1.0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"fps": self.fps, "internal_scale": self.internal_scale}
+
+
+@dataclass
+class PresetSchema(RuntimeJSON):
+    name: str = ""
+    emitter: EmitterSettings = field(default_factory=lambda: EmitterSettings(
+        type="generic",
+        rate_per_sec=10,
+        spawn_band=SpawnBand(0.0, 1.0),
+    ))
+    appearance: AppearanceSettings = field(
+        default_factory=lambda: AppearanceSettings(
+            palette=["#ffffff"], size_px=SizeRange(1, 1), sprite="res://runtime/default.png"
+        )
+    )
+    motion: MotionSettings = field(
+        default_factory=lambda: MotionSettings(0.1, 10.0, 0.5, 0.0, 0.0, 0.0)
+    )
+    accumulation: AccumulationSettings = field(
+        default_factory=lambda: AccumulationSettings(True, "heightmap", 32.0, 0.1)
+    )
+    obstacle: ObstacleSettings = field(
+        default_factory=lambda: ObstacleSettings("res://runtime/obstacles_mask.png", 0.0)
+    )
+    fx: FXSettings = field(
+        default_factory=lambda: FXSettings(0.0, BackgroundSettings(["#000000", "#000000"], False))
+    )
+    targets: TargetsSettings = field(default_factory=lambda: TargetsSettings(60, 1.0))
+    notes: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "name": self.name,
+            "emitter": self.emitter.to_dict(),
+            "appearance": self.appearance.to_dict(),
+            "motion": self.motion.to_dict(),
+            "accumulation": self.accumulation.to_dict(),
+            "obstacle": self.obstacle.to_dict(),
+            "fx": self.fx.to_dict(),
+            "targets": self.targets.to_dict(),
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class ForceEvent:
+    t: float
+    type: str
+    dir_deg: Optional[float] = None
+    speed: Optional[float] = None
+    dur: Optional[float] = None
+    center: Optional[List[float]] = None
+    radius: Optional[float] = None
+    vortex: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        self.t = clamp(self.t, min_value=0.0)
+        if self.dir_deg is not None:
+            self.dir_deg = clamp(self.dir_deg, min_value=0.0, max_value=360.0)
+        if self.speed is not None:
+            self.speed = clamp(self.speed, min_value=0.0, max_value=MAX_WIND_SPEED)
+        if self.dur is not None:
+            self.dur = clamp(self.dur, min_value=0.0)
+        if self.center is not None:
+            if len(self.center) != 2:
+                raise ValidationError("center must be a pair")
+            self.center = [clamp(c, min_value=0.0, max_value=1.0) for c in self.center]
+        if self.radius is not None:
+            self.radius = clamp(self.radius, min_value=0.0, max_value=MAX_TORNADO_RADIUS)
+        if self.vortex is not None:
+            self.vortex = clamp(self.vortex, min_value=0.0, max_value=MAX_VORTEX_SPEED)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"t": self.t, "type": self.type}
+        if self.dir_deg is not None:
+            data["dir_deg"] = self.dir_deg
+        if self.speed is not None:
+            data["speed"] = self.speed
+        if self.dur is not None:
+            data["dur"] = self.dur
+        if self.center is not None:
+            data["center"] = self.center
+        if self.radius is not None:
+            data["radius"] = self.radius
+        if self.vortex is not None:
+            data["vortex"] = self.vortex
+        return data
+
+
+@dataclass
+class ForcefieldSchema(RuntimeJSON):
+    timeline: List[ForceEvent] = field(default_factory=list)
+    use_prebaked_texture: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "timeline": [event.to_dict() for event in self.timeline],
+            "texture": {"use_prebaked": self.use_prebaked_texture},
+        }
+
+
+@dataclass
+class ClearRule:
+    trigger: str
+    action: str
+    at: Optional[str] = None
+    gte: Optional[float] = None
+    radius_px: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.radius_px is not None:
+            self.radius_px = clamp(self.radius_px, min_value=0.0, max_value=4096.0)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"trigger": self.trigger, "action": self.action}
+        if self.at is not None:
+            data["at"] = self.at
+        if self.gte is not None:
+            data["gte"] = self.gte
+        if self.radius_px is not None:
+            data["radius_px"] = self.radius_px
+        return data
+
+
+@dataclass
+class DrawOp:
+    op: str
+    pos: Optional[List[float]] = None
+    radius: Optional[float] = None
+    rect: Optional[List[float]] = None
+    mode: str = "solid"
+
+    def __post_init__(self) -> None:
+        if self.pos is not None:
+            if len(self.pos) != 2:
+                raise ValidationError("pos must have length 2")
+            self.pos = [clamp(p, min_value=0.0, max_value=1.0) for p in self.pos]
+        if self.radius is not None:
+            self.radius = clamp(self.radius, min_value=0.0, max_value=1.0)
+        if self.rect is not None:
+            if len(self.rect) != 4:
+                raise ValidationError("rect must have length 4")
+            self.rect = [clamp(r, min_value=0.0, max_value=1.0) for r in self.rect]
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"op": self.op, "mode": self.mode}
+        if self.pos is not None:
+            data["pos"] = self.pos
+        if self.radius is not None:
+            data["radius"] = self.radius
+        if self.rect is not None:
+            data["rect"] = self.rect
+        return data
+
+
+@dataclass
+class ObstaclesSchema(RuntimeJSON):
+    clear_rules: List[ClearRule] = field(default_factory=list)
+    draw_ops: List[DrawOp] = field(default_factory=list)
+    mask_path: str = "res://runtime/obstacles_mask.png"
+
+    def __post_init__(self) -> None:
+        self.mask_path = ensure_runtime_path(self.mask_path)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "clear_rules": [rule.to_dict() for rule in self.clear_rules],
+            "draw_ops": [op.to_dict() for op in self.draw_ops],
+            "mask": self.mask_path,
+        }
+
+
+@dataclass
+class SequenceTrack:
+    t: float
+    apply: Dict[str, str]
+
+    def __post_init__(self) -> None:
+        self.t = clamp(self.t, min_value=0.0)
+        self.apply = {key: ensure_runtime_path(value) for key, value in self.apply.items()}
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"t": self.t, "apply": self.apply}
+
+
+@dataclass
+class SequenceSchema(RuntimeJSON):
+    tracks: List[SequenceTrack] = field(default_factory=list)
+    loop: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "tracks": [track.to_dict() for track in self.tracks],
+            "loop": self.loop,
+        }
+
+
+@dataclass
+class CaptureSettings:
+    type: str
+    w: int
+    h: int
+    fps: int
+    dur_sec: float
+
+    def __post_init__(self) -> None:
+        self.w = int(clamp(float(self.w), min_value=1.0, max_value=float(MAX_EXPORT_RESOLUTION)))
+        self.h = int(clamp(float(self.h), min_value=1.0, max_value=float(MAX_EXPORT_RESOLUTION)))
+        self.fps = int(clamp(float(self.fps), min_value=1.0, max_value=240.0))
+        self.dur_sec = clamp(self.dur_sec, min_value=0.0, max_value=MAX_EXPORT_DURATION)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "w": self.w,
+            "h": self.h,
+            "fps": self.fps,
+            "dur_sec": self.dur_sec,
+        }
+
+
+@dataclass
+class ExporterSchema(RuntimeJSON):
+    capture: CaptureSettings = field(
+        default_factory=lambda: CaptureSettings("video", 1920, 1080, 60, 10.0)
+    )
+    watermark: Optional[Dict[str, Any]] = None
+    seed: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.seed is not None:
+            self.seed = int(clamp(float(self.seed), min_value=0.0, max_value=2**32 - 1))
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "version": self.version,
+            "capture": self.capture.to_dict(),
+        }
+        if self.watermark is not None:
+            data["watermark"] = self.watermark
+        if self.seed is not None:
+            data["seed"] = self.seed
+        return data
+
+
+@dataclass
+class SeasonalAdjust:
+    parameter: str
+    values: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"parameter": self.parameter, "values": self.values}
+
+
+@dataclass
+class TimekeeperSchema(RuntimeJSON):
+    region: str = "UTC"
+    adjustments: List[SeasonalAdjust] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "region": self.region,
+            "adjustments": [adj.to_dict() for adj in self.adjustments],
+        }
+
+
+@dataclass
+class UIHintsSchema(RuntimeJSON):
+    tips: List[str] = field(default_factory=list)
+    recommended_presets: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "tips": self.tips,
+            "recommended_presets": self.recommended_presets,
+        }
+
+
+@dataclass
+class AssetPackSchema(RuntimeJSON):
+    required_assets: List[str] = field(default_factory=list)
+    missing_assets: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "required_assets": self.required_assets,
+            "missing_assets": self.missing_assets,
+        }
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "MAX_PARTICLE_RATE",
+    "MAX_WIND_SPEED",
+    "ValidationError",
+    "RuntimeJSON",
+    "PresetSchema",
+    "ForcefieldSchema",
+    "ObstaclesSchema",
+    "SequenceSchema",
+    "ExporterSchema",
+    "TimekeeperSchema",
+    "UIHintsSchema",
+    "AssetPackSchema",
+    "clamp",
+    "ensure_runtime_path",
+]

--- a/agents/sequence_agent.py
+++ b/agents/sequence_agent.py
@@ -1,0 +1,23 @@
+"""Simulation sequence agent to orchestrate preset/forcefile changes."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .schema import SequenceSchema, SequenceTrack
+
+
+@dataclass
+class SequenceRequest:
+    tracks: Iterable[SequenceTrack]
+    loop: bool = True
+
+
+class SequenceAgent:
+    """Build a sequence schema from provided timeline tracks."""
+
+    def generate(self, request: SequenceRequest) -> SequenceSchema:
+        return SequenceSchema(tracks=list(request.tracks), loop=request.loop)
+
+
+__all__ = ["SequenceAgent", "SequenceRequest"]

--- a/agents/timekeeper_agent.py
+++ b/agents/timekeeper_agent.py
@@ -1,0 +1,23 @@
+"""Timekeeper agent manages time and seasonal adjustments."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .schema import SeasonalAdjust, TimekeeperSchema
+
+
+@dataclass
+class TimekeeperRequest:
+    region: str
+    adjustments: Iterable[SeasonalAdjust]
+
+
+class TimekeeperAgent:
+    """Create timekeeper schemas from scheduling data."""
+
+    def generate(self, request: TimekeeperRequest) -> TimekeeperSchema:
+        return TimekeeperSchema(region=request.region, adjustments=list(request.adjustments))
+
+
+__all__ = ["TimekeeperAgent", "TimekeeperRequest"]

--- a/agents/uihints_agent.py
+++ b/agents/uihints_agent.py
@@ -1,0 +1,23 @@
+"""UI hints agent surfaces tutorial suggestions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .schema import UIHintsSchema
+
+
+@dataclass
+class UIHintsRequest:
+    tips: Iterable[str]
+    recommended_presets: Iterable[str]
+
+
+class UIHintsAgent:
+    """Aggregate tutorial hints into schema compliant JSON."""
+
+    def generate(self, request: UIHintsRequest) -> UIHintsSchema:
+        return UIHintsSchema(tips=list(request.tips), recommended_presets=list(request.recommended_presets))
+
+
+__all__ = ["UIHintsAgent", "UIHintsRequest"]

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+
+from agents.forcefield_agent import ForceEventSpec, ForceFieldAgent, ForcefieldConstraints, ForcefieldRequest
+from agents.preset_agent import PresetAgent, PresetConstraints, PresetRequest
+from agents.schema import MAX_PARTICLE_RATE, clamp
+
+
+class SchemaClampTests(unittest.TestCase):
+    def test_clamp_enforces_bounds(self) -> None:
+        self.assertEqual(clamp(500.0, min_value=0.0, max_value=200.0), 200.0)
+        self.assertEqual(clamp(-10.0, min_value=0.0, max_value=200.0), 0.0)
+
+
+class PresetAgentTests(unittest.TestCase):
+    def test_particle_rate_is_clamped(self) -> None:
+        agent = PresetAgent(PresetConstraints(max_particles=1_000))
+        schema = agent.generate(
+            PresetRequest(prompt="storm of petals", desired_rate=MAX_PARTICLE_RATE * 2, base_name="Storm")
+        )
+        self.assertLessEqual(schema.emitter.rate_per_sec, 1_000)
+
+
+class ForcefieldAgentTests(unittest.TestCase):
+    def test_wind_speed_is_clamped(self) -> None:
+        agent = ForceFieldAgent(ForcefieldConstraints(max_speed=150.0))
+        schema = agent.generate(
+            ForcefieldRequest(
+                prompt="intense gust",
+                events=[ForceEventSpec(t=0.0, type="gust", dir_deg=90.0, speed=500.0, dur=5.0)],
+            )
+        )
+        self.assertEqual(schema.timeline[0].speed, 150.0)
+
+
+class CLITests(unittest.TestCase):
+    def test_cli_generates_runtime_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            runtime_dir = repo_root / "runtime"
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    str(Path(__file__).resolve().parents[1] / "tools" / "generate_runtime_files.py"),
+                    "--repo-root",
+                    str(repo_root),
+                ]
+            )
+            preset_path = runtime_dir / "preset.json"
+            self.assertTrue(preset_path.exists())
+            data = json.loads(preset_path.read_text(encoding="utf-8"))
+            self.assertEqual(data["version"], "1.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/generate_runtime_files.py
+++ b/tools/generate_runtime_files.py
@@ -1,0 +1,243 @@
+"""Utility script to generate runtime JSON files using agents."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from agents import (  # noqa: E402  # pylint: disable=wrong-import-position
+    AssetPackAgent,
+    AssetPackRequest,
+    ExporterAgent,
+    ExporterRequest,
+    ForceFieldAgent,
+    ForceEventSpec,
+    ForcefieldRequest,
+    ObstacleAgent,
+    ObstacleRequest,
+    PresetAgent,
+    PresetRequest,
+    SequenceAgent,
+    SequenceRequest,
+    TimekeeperAgent,
+    TimekeeperRequest,
+    UIHintsAgent,
+    UIHintsRequest,
+)
+from agents.schema import (  # noqa: E402  # pylint: disable=wrong-import-position
+    CaptureSettings,
+    ClearRule,
+    DrawOp,
+    SeasonalAdjust,
+    SequenceTrack,
+)
+
+DEFAULT_OUTPUTS = {
+    "preset": "preset.json",
+    "forcefield": "forcefield.json",
+    "sequence": "sequence.json",
+    "timefx": "timefx.json",
+    "uihints": "uihints.json",
+    "exporter": "capture.json",
+    "assets": "assets.json",
+    "obstacles": "obstacles.json",
+}
+
+
+def write_json(data: Dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def build_preset(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    request = PresetRequest(
+        prompt=config["prompt"],
+        palette=config.get("palette"),
+        emitter_type=config.get("emitter_type", "generic"),
+        base_name=config.get("base_name", config.get("prompt", "preset")),
+        desired_rate=config.get("desired_rate", 2000),
+        burst_interval=config.get("burst", {}).get("interval_sec"),
+        burst_count=config.get("burst", {}).get("count"),
+        sprite=config.get("sprite", "res://runtime/preset_sprite.png"),
+        notes=config.get("notes"),
+    )
+    schema = PresetAgent().generate(request)
+    return schema.to_dict()
+
+
+def build_forcefield(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    event_specs = [
+        ForceEventSpec(
+            t=event.get("t", 0.0),
+            type=event["type"],
+            dir_deg=event.get("dir_deg"),
+            speed=event.get("speed"),
+            dur=event.get("dur"),
+            center=event.get("center"),
+            radius=event.get("radius"),
+            vortex=event.get("vortex"),
+        )
+        for event in config.get("events", [])
+    ]
+    schema = ForceFieldAgent().generate(
+        ForcefieldRequest(
+            prompt=config.get("prompt", ""),
+            events=event_specs,
+            use_prebaked_texture=config.get("use_prebaked_texture", False),
+        )
+    )
+    return schema.to_dict()
+
+
+def build_obstacles(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    clear_rules = [ClearRule(**rule) for rule in config.get("clear_rules", [])]
+    draw_ops = [DrawOp(**op) for op in config.get("draw_ops", [])]
+    schema = ObstacleAgent().generate(
+        ObstacleRequest(
+            clear_rules=clear_rules,
+            draw_ops=draw_ops,
+            mask_path=config.get("mask_path", "res://runtime/obstacles_mask.png"),
+        )
+    )
+    return schema.to_dict()
+
+
+def build_sequence(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    tracks = [SequenceTrack(t=track.get("t", 0.0), apply=track.get("apply", {})) for track in config.get("tracks", [])]
+    schema = SequenceAgent().generate(SequenceRequest(tracks=tracks, loop=config.get("loop", True)))
+    return schema.to_dict()
+
+
+def build_timekeeper(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    adjustments = [
+        SeasonalAdjust(parameter=adj["parameter"], values=adj.get("values", {}))
+        for adj in config.get("adjustments", [])
+    ]
+    schema = TimekeeperAgent().generate(
+        TimekeeperRequest(region=config.get("region", "UTC"), adjustments=adjustments)
+    )
+    return schema.to_dict()
+
+
+def build_uihints(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    schema = UIHintsAgent().generate(
+        UIHintsRequest(tips=config.get("tips", []), recommended_presets=config.get("recommended_presets", []))
+    )
+    return schema.to_dict()
+
+
+def build_exporter(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    capture = (
+        CaptureSettings(**config["capture"]) if config.get("capture") else CaptureSettings("video", 1920, 1080, 60, 10.0)
+    )
+    schema = ExporterAgent().generate(
+        ExporterRequest(capture=capture, watermark=config.get("watermark"), seed=config.get("seed"))
+    )
+    return schema.to_dict()
+
+
+def build_assets(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    schema = AssetPackAgent().generate(
+        AssetPackRequest(
+            required_assets=config.get("required_assets", []),
+            available_assets=config.get("available_assets", []),
+        )
+    )
+    return schema.to_dict()
+
+
+BUILDERS = {
+    "preset": build_preset,
+    "forcefield": build_forcefield,
+    "obstacles": build_obstacles,
+    "sequence": build_sequence,
+    "timefx": build_timekeeper,
+    "uihints": build_uihints,
+    "exporter": build_exporter,
+    "assets": build_assets,
+}
+
+
+def generate_files(config: Dict[str, Any], repo_root: Path) -> Dict[str, Path]:
+    outputs: Dict[str, Path] = {}
+    for key, builder in BUILDERS.items():
+        section = config.get(key)
+        result = builder(section) if section is not None else None
+        if result is None:
+            continue
+        filename = DEFAULT_OUTPUTS[key]
+        output_path = repo_root / "runtime" / filename
+        write_json(result, output_path)
+        outputs[key] = output_path
+    return outputs
+
+
+def load_config(path: Optional[Path]) -> Dict[str, Any]:
+    if path is None:
+        return {
+            "preset": {
+                "prompt": "Sample petals gently swaying",
+                "palette": ["#ffd6e7", "#ffc1dc", "#ffe9f2"],
+            },
+            "forcefield": {
+                "prompt": "Calm breeze with a short gust",
+                "events": [
+                    {"t": 0, "type": "wind", "dir_deg": 180, "speed": 120},
+                    {"t": 30, "type": "gust", "dir_deg": 150, "speed": 240, "dur": 6},
+                ],
+            },
+            "sequence": {
+                "tracks": [
+                    {
+                        "t": 0,
+                        "apply": {
+                            "preset": "res://runtime/preset.json",
+                            "force": "res://runtime/forcefield.json",
+                        },
+                    }
+                ],
+                "loop": True,
+            },
+        }
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate runtime JSON files using the agent package")
+    parser.add_argument("--config", type=Path, help="JSON file describing agent inputs", default=None)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config(args.config)
+    outputs = generate_files(config, args.repo_root)
+    for name, path in outputs.items():
+        print(f"wrote {name}: {path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()


### PR DESCRIPTION
## Summary
- add a shared agent schema module with clamping utilities and runtime path validation
- implement individual agent modules for presets, forcefields, obstacles, sequences, timekeeper, UI hints, exporters, and asset packs
- add a CLI to build runtime JSON files and accompanying unit tests covering clamping and CLI behaviour

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68df654c35c8832686f23c96bd9836b1